### PR TITLE
Swallow unhelpful IOErrors printed by queue feeder threads

### DIFF
--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -84,6 +84,7 @@ class ExceptionsTest(T.TestCase):
             [serialize_error(get_ec_value(call)) for call in print_exc_mock.call_args_list],
             [serialize_error(expected_exception)] * count)
 
+    @vimap.testing.queue_feed_ignore_ioerrors_mock
     @mock.patch.object(vimap.exception_handling, 'print_warning', autospec=True)
     @mock.patch.object(vimap.exception_handling, 'print_exception', autospec=True)
     def test_exception_before_iteration(self, print_exc_mock, print_warning_mock):
@@ -128,6 +129,7 @@ class ExceptionsTest(T.TestCase):
         ]
         T.assert_sorted_equal(res_to_compare, expected_res_to_compare)
 
+    @vimap.testing.queue_feed_ignore_ioerrors_mock
     @mock.patch.object(vimap.exception_handling, 'clean_print', autospec=True)
     def test_exception_formatting(self, clean_print_mock):
         '''Test the formatting of exceptions (they should include the error
@@ -140,6 +142,7 @@ class ExceptionsTest(T.TestCase):
             args[0],
             "\x1b[31m[Worker Exception] ValueError: {0} curley braces!\x1b[0m\n  File ")
 
+    @vimap.testing.queue_feed_ignore_ioerrors_mock
     @mock.patch.object(vimap.exception_handling, 'print_warning', autospec=True)
     @mock.patch.object(vimap.exception_handling, 'print_exception', autospec=True)
     def test_exception_with_curleys(self, print_exc_mock, print_warning_mock):

--- a/vimap/testing.py
+++ b/vimap/testing.py
@@ -4,6 +4,8 @@ Provides methods for tests.
 import functools
 import itertools
 import multiprocessing
+import multiprocessing.queues
+import traceback
 from collections import namedtuple
 
 import mock
@@ -26,6 +28,39 @@ def no_warnings():
         vimap.exception_handling,
         'print_warning',
         lambda *args, **kwargs: T.assert_not_reached())
+
+
+# for queue_feed_routine_ignoring_ioerrors
+_original_queue_feed = multiprocessing.queues.Queue._feed
+
+
+@mock.patch.object(traceback, 'print_exc', lambda: None)
+def queue_feed_routine_ignoring_ioerrors(*args, **kwargs):
+    """Mock routine, which you can patch in, in the stead of
+    multiprocessing.queues.Queue._feed. For convenience, just
+    use the queue_feed_ignore_ioerrors_mock decorator.
+
+    On certain tests, where workers die in unexpected places,
+    IOErrors will be printed for queue feeding. It doesn't seem
+    we are handling these edge cases incorrectly, so for now we
+    silence the exceptions (as to not be distracted by them and
+    possibly overlook other ones). The exceptions look like,
+
+    Traceback (most recent call last):
+      File "/usr/lib64/python2.7/multiprocessing/queues.py", line 266, in _feed
+        send(obj)
+    IOError: [Errno 32] Broken pipe
+
+    They are only raised by the queue threads, so won't be caught
+    by our testing framework anyway.
+    """
+    return _original_queue_feed(*args, **kwargs)
+
+
+queue_feed_ignore_ioerrors_mock = mock.patch.object(
+    multiprocessing.queues.Queue,
+    "_feed",
+    staticmethod(queue_feed_routine_ignoring_ioerrors))
 
 
 class DebugPool(vimap.pool.VimapPool):


### PR DESCRIPTION
In certain tests, where workers die in unexpected places, IOErrors will be printed for queue feeding. It doesn't seem we are handling these edge cases incorrectly, so for now we silence the exceptions (as to not be distracted by them and possibly overlook other ones).

However (as possibly obvious by what I wrote), I'm not comfortable doing this for non-testing cases (i.e., always muting those errors). They seem to only come up in exceptional cases, which hopefully indicate errors that users of vimap will handle (i.e. catch the exception in the worker routine, or fix the associated bug).
